### PR TITLE
Added optional arguments to plot fermi surface outside first Brillouin zone

### DIFF
--- a/src/ifermi/surface.py
+++ b/src/ifermi/surface.py
@@ -419,7 +419,7 @@ class FermiSurface(MSONable):
         property_kpoints: np.ndarray | None = None,
         calculate_dimensionality: bool = False,
         supercell_dim: Tuple[int, int, int] = (3, 3, 3),
-        trim_surface: bool = True,
+        trim_to_first_bz: bool = True,
     ) -> FermiSurface:
         """Create a FermiSurface from a pymatgen band structure object.
 
@@ -452,7 +452,7 @@ class FermiSurface(MSONable):
                 Must be used in combination with ``data``.
             calculate_dimensionality: Whether to calculate isosurface dimensionalities.
             supercell_dim: The supercell mesh dimensions.
-            trim_surface: If true, only includes Fermi surface within one Brillouin
+            trim_to_first_bz: If true, only includes Fermi surface within one Brillouin
                 zone. If false, include Fermi surface within entire supercell.
 
         Returns:
@@ -504,7 +504,7 @@ class FermiSurface(MSONable):
             smooth=smooth,
             calculate_dimensionality=calculate_dimensionality,
             property_interpolator=interpolator,
-            trim_surface=trim_surface,
+            trim_to_first_bz=trim_to_first_bz,
         )
 
         return cls(isosurfaces, reciprocal_space, structure)
@@ -549,7 +549,7 @@ def compute_isosurfaces(
     smooth: bool = False,
     calculate_dimensionality: bool = False,
     property_interpolator: LinearInterpolator | None = None,
-    trim_surface: bool = True,
+    trim_to_first_bz: bool = True,
 ) -> dict[Spin, list[Isosurface]]:
     """Compute the isosurfaces at a particular energy level.
 
@@ -574,7 +574,7 @@ def compute_isosurfaces(
         calculate_dimensionality: Whether to calculate isosurface dimensionality.
         property_interpolator: An interpolator class for interpolating properties
             onto the surface. If ``None``, no properties will be calculated.
-        trim_surface: If true, only includes Fermi surface within one Brillouin
+        trim_to_first_bz: If true, only includes Fermi surface within one Brillouin
             zone. If false, include Fermi surface within entire supercell.
 
     Returns:
@@ -636,7 +636,7 @@ def _calculate_band_isosurfaces(
     smooth: bool,
     calculate_dimensionality: bool,
     property_interpolator: LinearInterpolator | None,
-    trim_surface: bool = True,
+    trim_to_first_bz: bool = True,
 ):
     """Helper function to calculate the connected isosurfaces for a band."""
     from skimage.measure import marching_cubes
@@ -700,7 +700,7 @@ def _calculate_band_isosurfaces(
     for (subverts, subfaces), idx in zip(subsurfaces, mapping):
         # convert vertices to cartesian coordinates
         subverts = np.dot(subverts, rlat)
-        if trim_surface:
+        if trim_to_first_bz:
             subverts, subfaces = trim_surface(reciprocal_space, subverts, subfaces)
 
         if len(subverts) == 0:

--- a/src/ifermi/surface.py
+++ b/src/ifermi/surface.py
@@ -418,7 +418,7 @@ class FermiSurface(MSONable):
         property_data: dict[Spin, np.ndarray] | None = None,
         property_kpoints: np.ndarray | None = None,
         calculate_dimensionality: bool = False,
-        supercell_dim: Tuple[int, int, int] = (3, 3, 3),
+        supercell_dim: tuple[int, int, int] = (3, 3, 3),
         trim_to_first_bz: bool = True,
     ) -> FermiSurface:
         """Create a FermiSurface from a pymatgen band structure object.

--- a/src/ifermi/surface.py
+++ b/src/ifermi/surface.py
@@ -614,7 +614,7 @@ def compute_isosurfaces(
                 smooth,
                 calculate_dimensionality,
                 property_interpolator,
-                trim_surface,
+                trim_to_first_bz,
             )
             spin_isosurface.extend(band_isosurfaces)
 


### PR DESCRIPTION
Added supercell_dim optional input to FermiSurface.from_band_structure with default of (3,3,3), so default functionality is unchanged.

Added trim_surface bool optional input to FermiSurface.from_band_structure, compute_isosurfaces, and _calculate_band_isosurfaces. Default is to trim, so default functionality is unchanged.
