### PR TITLE
get_cmap deprecation

### DIFF
--- a/src/ifermi/plot.py
+++ b/src/ifermi/plot.py
@@ -361,7 +361,7 @@ class FermiSurfacePlotter:
         Returns:
             The Fermi surface plot data.
         """
-        from matplotlib.cm import get_cmap
+        from matplotlib.pyplot import get_cmap
 
         if not spin:
             spin = self.fermi_surface.spins


### PR DESCRIPTION
See the [matplotlib changelog](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.9.0.html#top-level-cmap-registration-and-access-functions-in-mpl-cm) for 3.9.0. Using the `matplotlib.pyplot` should be backward-compatible. Merging this will allow @jmmshn to continue with https://github.com/materialsproject/crystaltoolkit/pull/391