### PR TITLE
Change import statement for spglib module

### DIFF
--- a/src/ifermi/interpolate.py
+++ b/src/ifermi/interpolate.py
@@ -79,7 +79,7 @@ class FourierInterpolator:
         from BoltzTraP2.units import eV
         from pymatgen.io.ase import AseAtomsAdaptor
         from scipy.constants import physical_constants
-        from spglib import spglib
+        import spglib
 
         from ifermi.boltztrap import bands_fft
         from ifermi.kpoints import sort_boltztrap_to_spglib


### PR DESCRIPTION
for spglib > 2.*, get_ir_reciprocal_mesh() is defined in spglib.kpoints, instead of spglib.spglib. using "import spglib" will make it work with spglib 2.*.